### PR TITLE
Added flatpak Steam config path

### DIFF
--- a/ProtonDB-to-Steam-Library.py
+++ b/ProtonDB-to-Steam-Library.py
@@ -64,7 +64,8 @@ def get_protondb_rating(app_id):
 def get_sharedconfig_path():
     possible_paths = ["~/.local/share/Steam/userdata",
                       "~/.steam/steam/userdata",
-                      "~/.steam/root/userdata"]
+                      "~/.steam/root/userdata",
+                      "~/.var/app/com.valvesoftware.Steam/.local/share/Steam/userdata"]
 
     base_path = ""
 


### PR DESCRIPTION
The added path is the default config path for Steam installed via Flatpak.
So in the case of a flatpak install it isn't necessary to give the path manually to the command